### PR TITLE
Fix AX bigger than 2^250 and break circom in bid_nft

### DIFF
--- a/circom/business/bid_nft.circom
+++ b/circom/business/bid_nft.circom
@@ -64,7 +64,7 @@ template BidNFT() {
     // circuits: check biddingAmount < 2 ^ 250 & biddingAmount > dataPath[3]'s leafValues[2]
     component biddingAmountRangeCheck = Check2PowerRangeFE(250);
     biddingAmountRangeCheck.in <== biddingAmount;
-    component lessthan = LessThan253(253);
+    component lessthan = LessThanFE(250);
     lessthan.in[0] <== dataPath[3][BiddingAmountOffset];
     lessthan.in[1] <== biddingAmount;
     andmany.in[andmanyOffset] <== lessthan.out * biddingAmountRangeCheck.out;
@@ -107,7 +107,7 @@ template BidNFT() {
     }
     var balance = getBalance.out;
 
-    component enoughBalance = GreaterEqThan253(253);
+    component enoughBalance = GreaterEqThanFE(250);
     enoughBalance.in[0] <== balance;
     enoughBalance.in[1] <== biddingAmount;
     andmany.in[andmanyOffset] <== bidderBalanceIndexCheck.out * enoughBalance.out;

--- a/circom/business/bid_nft.circom
+++ b/circom/business/bid_nft.circom
@@ -64,7 +64,7 @@ template BidNFT() {
     // circuits: check biddingAmount < 2 ^ 250 & biddingAmount > dataPath[3]'s leafValues[2]
     component biddingAmountRangeCheck = Check2PowerRangeFE(250);
     biddingAmountRangeCheck.in <== biddingAmount;
-    component lessthan = LessThan(250);
+    component lessthan = LessThan253(253);
     lessthan.in[0] <== dataPath[3][BiddingAmountOffset];
     lessthan.in[1] <== biddingAmount;
     andmany.in[andmanyOffset] <== lessthan.out * biddingAmountRangeCheck.out;
@@ -107,7 +107,7 @@ template BidNFT() {
     }
     var balance = getBalance.out;
 
-    component enoughBalance = GreaterEqThan(250);
+    component enoughBalance = GreaterEqThan253(253);
     enoughBalance.in[0] <== balance;
     enoughBalance.in[1] <== biddingAmount;
     andmany.in[andmanyOffset] <== bidderBalanceIndexCheck.out * enoughBalance.out;

--- a/circom/utils/swap_aux.circom
+++ b/circom/utils/swap_aux.circom
@@ -11,7 +11,17 @@ include "./bit.circom";
  * Use these templates carefully.
  */
 
+
 template Check2PowerRangeFE(N) {
+    /*
+     * N must be less than 254 bits
+     * Each check by such code:
+     *   component a= Check2PowerRangeFE(254);
+     *   a.in <== 10;
+     *   a.out === 1;
+     * It will pop up error as it will exceed field size.
+     */
+    assert(N <= 253);
     signal input in;
     signal output out;
 
@@ -23,6 +33,28 @@ template Check2PowerRangeFE(N) {
     eq.in[1] <== in;
 
     out <== eq.out;
+}
+
+template LessThan253(N) {
+    signal input in[2];
+    signal output out;
+
+    var diff = in[1] - in[0] - 1;
+
+    component checkDiff = Check2PowerRangeFE(N);
+    checkDiff.in <== diff;
+    out <== checkDiff.out;
+}
+
+template GreaterEqThan253(N) {
+    signal input in[2];
+    signal output out;
+
+    var diff = in[0] - in[1];
+
+    component checkDiff = Check2PowerRangeFE(N);
+    checkDiff.in <== diff;
+    out <== checkDiff.out;
 }
 
 template AndMany(N) {

--- a/circom/utils/swap_aux.circom
+++ b/circom/utils/swap_aux.circom
@@ -35,7 +35,7 @@ template Check2PowerRangeFE(N) {
     out <== eq.out;
 }
 
-template LessThan253(N) {
+template LessThanFE(N) {
     signal input in[2];
     signal output out;
 
@@ -46,7 +46,7 @@ template LessThan253(N) {
     out <== checkDiff.out;
 }
 
-template GreaterEqThan253(N) {
+template GreaterEqThanFE(N) {
     signal input in[2];
     signal output out;
 


### PR DESCRIPTION
The issue is:
When setKey's arg[4] for AX is large than 2^250, it will break bid_nft's Num2Bit in original lessthan/greatequalthen lib component. 
(This is because bid_nft's arg[4] is for biddingAmount and need check value is larger than the original biddingAmount, and regardless what op is, we will go through all constraints in all circom codes.) circomlib's lessthan(N)/greatequalthen(N) component directly transfer the input into Num2Bits and it will breach the constrain inside it if input is larger than the 2^N.

This fix makes the lessthanFE and greatequalthenFE function to accept max 253bits number, and also follow the FE rule. 

However, snark bn128's field range may be a little bit large than 2^253, so it may still have rare chance that AX is larger than 2^253. It does not matter as it will not fail the circom. Even AX is larger than 2^253, current lessthanFE and greatequalthenFE will not breach any constraint, just the output is 0. Thus just the bid_nft circom's out will be 0. As the op is SetKey, not bidNFT, so the 0 result will not be counted.